### PR TITLE
cargo: Bump bindgen dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ default = ["link-vlc"]
 libc = "^0.2.0"
 
 [build-dependencies.bindgen]
-version = "^0.25"
+version = "^0.57"
 


### PR DESCRIPTION
The current bindgen version used by the module is `0.25`
Sadly, this means that bindgen relies on `aster`, a deprecated crate relying on an old version of `syntex_syntax`. Currently, the module (and other plugins depending on it, such as https://github.com/Geal/rust-vlc-demux, do not build

```
error[E0423]: expected function, tuple struct or tuple variant, found struct `ast::Name`
   --> /home/kagounard/.cargo/registry/src/github.com-1ecc6299db9ec823/syntex_syntax-0.58.1/src/symbol.rs:146:27
    |
146 |                       name: ast::Name($index),
    |                             ^^^^^^^^^
...
165 | / declare_keywords! {
166 | |     // Invalid identifier
167 | |     (0,  Invalid,        "")
168 | |
...   |
231 | |     (56, CrateRoot, "{{root}}")
232 | | }
    | |_- in this macro invocation
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

Extrait of `cargo tree`:
```
> cargo tree 
vlc_module v0.1.0
└── libc v0.2.91
[build-dependencies]
└── bindgen v0.25.5
    ├── aster v0.41.0
    │   └── syntex_syntax v0.58.1
 ```
 
 bindgen has since moved on from `aster` in later versions